### PR TITLE
Multiple updates/improvements

### DIFF
--- a/app/views/issues/_changesets.html.erb
+++ b/app/views/issues/_changesets.html.erb
@@ -9,8 +9,8 @@
                :path   => "",
                :rev    => changeset.identifier) + ')') if changeset.filechanges.any? %>
          <small><%= changeset.project.identifier if changeset.project.id != @issue.project.id %></small>
-        <% if changeset.project.module_enabled?('gitbranchdisplay') and changeset.project.repository.type == "Repository::Git" %>
-           <% branches = @issue.branches(changeset.project.repository, changeset) %>
+        <% if changeset.project.module_enabled?('gitbranchdisplay') and changeset.repository.type == "Repository::Git" %>
+           <% branches = @issue.branches(changeset.repository, changeset) %>
            <% if branches.length %>
               <span class="changeset-list"
                     style="float:right; padding-left: 6px; max-width: 60%; font-size: 9px; margin-top: -4px; padding-top: 4px; max-height: 7em; overflow-y: auto;"

--- a/app/views/issues/_changesets.html.erb
+++ b/app/views/issues/_changesets.html.erb
@@ -9,7 +9,7 @@
                :repository_id => changeset.repository.identifier_param,
                :path   => "",
                :rev    => changeset.identifier) + ')') if changeset.filechanges.any? %>
-         <small><%= changeset.project.identifier if changeset.project.id != @issue.project.id %></small>
+         <small><%= (changeset.repository.identifier if changeset.repository.identifier != '') || (changeset.project.identifier if changeset.project.id != @issue.project.id) %></small>
         <% if changeset.project.module_enabled?('gitbranchdisplay') and changeset.repository.type == "Repository::Git" %>
            <% branches = @issue.branches(changeset.repository, changeset) %>
            <% if branches.length %>
@@ -17,7 +17,14 @@
                     style="float:right; padding-left: 6px; max-width: 60%; font-size: 9px; margin-top: -4px; padding-top: 4px; max-height: 7em; overflow-y: auto;"
               ><% master_branches = branches.grep(/^[\w-]*master$/) %>
                <%= raw((master_branches.size > 0 ? master_branches : branches).collect{ |branch|
-                   link_to(branch, {:controller => 'repositories', :action => 'show', :id => changeset.project, :rev => branch}, :title => branch)
+                   link_to(branch, {
+                       :controller => 'repositories',
+                       :action => 'show',
+                       :id => changeset.project,
+                       :repository_id => changeset.repository.identifier_param,
+                       :path => "",
+                       :rev => branch
+                   } , :title => branch)
                 }.compact.join('<br/>')) %></span>
             <% end %>
          <% end %>

--- a/app/views/issues/_changesets.html.erb
+++ b/app/views/issues/_changesets.html.erb
@@ -1,47 +1,30 @@
 <% changesets.each do |changeset| %>
    <div class="changeset <%= cycle('odd', 'even') %>">
       <p><%= link_to_revision(changeset, changeset.project,
-         :text => "#{l(:label_revision)} #{changeset.format_identifier}") %><br />
+         :text => "#{l(:label_revision)} #{changeset.format_identifier}") %>
+         <%= raw('(' + link_to('diff',
+               :controller => 'repositories',
+               :action => 'diff',
+               :id     => changeset.project,
+               :path   => "",
+               :rev    => changeset.identifier) + ')') if changeset.filechanges.any? %>
+         <small><%= changeset.project.identifier if changeset.project.id != @issue.project.id %></small>
+        <% if changeset.project.module_enabled?('gitbranchdisplay') and changeset.project.repository.type == "Repository::Git" %>
+           <% branches = @issue.branches(changeset.project.repository, changeset) %>
+           <% if branches.length %>
+              <span class="changeset-list"
+                    style="float:right; padding-left: 6px; max-width: 60%; font-size: 9px; margin-top: -4px; padding-top: 4px; max-height: 7em; overflow-y: auto;"
+              ><% master_branches = branches.grep(/^[\w-]*master$/) %>
+               <%= raw((master_branches.size > 0 ? master_branches : branches).collect{ |branch|
+                   link_to(branch, {:controller => 'repositories', :action => 'show', :id => changeset.project, :rev => branch}, :title => branch)
+                }.compact.join('<br/>')) %></span>
+            <% end %>
+         <% end %>
+         <br />
          <span class="author"><%= authoring(changeset.committed_on, changeset.author) %></span>
       </p>
       <div class="wiki">
          <%= textilizable(changeset, :comments) %>
       </div>
-      
-      <% if @project.module_enabled?('gitbranchdisplay') and @project.repository.type == "Git" %>
-       <% puts @project.repository.type %>
-         <%
-           @issue.assert_repo_exists(@project.repository)
-           branches_stripped = @issue.branches(@project.repository, changeset)
-           tags_stripped = @issue.tags(@project.repository, changeset)
-        %>
-        <div id="tags">
-           <p><%= l(:closest_tag) %>
-              <% if !tags_stripped.empty? %>
-                 <%= tags_stripped %>
-              <% else %>
-                 <%= l(:no_tags_found) %>
-              <% end %>
-           </p>
-        </div>
-        <div id="branches">
-           <%= l(:commit_located_on) %><%= branches_stripped.length %> <%= l(:branches_text) %> 
-           <% if branches_stripped.length > @issue.threshold_level %>
-              <a href="#" class="sort desc" onclick="<%= "Effect.toggle('#{changeset.revision}', 'appear'); return false;" %>"><%= l(:show_more) %></a>
-           <% end %>
-           <ul>
-              <% branches_stripped[0,@issue.threshold_level].each do |branch| %>
-                 <li><%= branch %></li>
-              <% end %>
-              <% if branches_stripped.length > @issue.threshold_level %>
-                 <div id="<%= "#{changeset.revision}" %>" style="display: none; overflow-x: visible; overflow-y: visible; ">
-                    <% branches_stripped[@issue.threshold_level, branches_stripped.length].each do |branch| %>
-                       <li><%= branch %></li>
-                    <% end %>
-                 </div>
-              <% end %>
-           </ul>
-        </div>
-      <% end %>
    </div>
 <% end %>

--- a/app/views/issues/_changesets.html.erb
+++ b/app/views/issues/_changesets.html.erb
@@ -1,11 +1,12 @@
 <% changesets.each do |changeset| %>
    <div class="changeset <%= cycle('odd', 'even') %>">
-      <p><%= link_to_revision(changeset, changeset.project,
+      <p><%= link_to_revision(changeset, changeset.repository,
          :text => "#{l(:label_revision)} #{changeset.format_identifier}") %>
          <%= raw('(' + link_to('diff',
                :controller => 'repositories',
                :action => 'diff',
                :id     => changeset.project,
+               :repository_id => changeset.repository.identifier_param,
                :path   => "",
                :rev    => changeset.identifier) + ')') if changeset.filechanges.any? %>
          <small><%= changeset.project.identifier if changeset.project.id != @issue.project.id %></small>

--- a/init.rb
+++ b/init.rb
@@ -16,6 +16,6 @@ Redmine::Plugin.register :redmine_gitbranchdisplay do
   end
 end
 
-Dispatcher.to_prepare do
+Rails.configuration.to_prepare do
   Issue.send(:include, IssueChangesetHelperPatch)
 end


### PR DESCRIPTION
- Fix for Redmine 2.6
- Support multiple repositories
- Save list of branches in a "changeset.branches" column. Save a hash of all repo heads to detect when changeset.branches needs to be updated.

Currently lacking migration script to add changeset.branches column.
